### PR TITLE
Switch to foundation slack invite

### DIFF
--- a/index.md
+++ b/index.md
@@ -74,7 +74,7 @@ If you'd like to support our chapter events through sponsorship, please reach ou
   - **[OWASP Melbourne Meetup.com
     page](http://www.meetup.com/Application-Security-OWASP-Melbourne)**.
   - [Twitter, but of course\!](http://twitter.com/OWASPmelbourne)
-  - [Slack, yes we have that too\!](https://owasp-slack.herokuapp.com/)
+  - [Slack, yes we have that too\!](https://owasp.org/slack/invite)
     - We're on Slack Channels `#chapter-melbourne` and `#appsec-day`
   - [but the Melbourne Chapter is more social on Discord](https://discord.gg/uAWze2B) come say hi :)
   


### PR DESCRIPTION
To avoid the problems around the herokuapp going down toward the end of the month due to usage limits a new mechanism has been setup. It's also simple for the foundation to make a redirect for /slack/invite for future changes as well.